### PR TITLE
Support a customized TTL value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,11 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "dev": true
     },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://nexus.internal.33across.com/repository/npm/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
     "redis": {
       "version": "2.8.0",
       "resolved": "https://nexus.internal.33across.com/repository/npm/redis/-/redis-2.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "cache-register": "^0.8.0",
     "redis": "^2.8.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 
 const cr = require('cache-register');
+const _ = require('lodash');
 const {BaseStorage} = cr.storage;
 
 class RedisStorage extends BaseStorage {
@@ -34,6 +35,8 @@ class RedisStorage extends BaseStorage {
       const args = [key, JSON.stringify(d)];
       if(typeof(this.ttl) === 'number') {
         args.push("PX", this.ttl);
+      } else if(_.isFunction(this.ttl)) {
+        args.push("PX", this.ttl());
       }
 
       this.redis.set(...args, function(err, data) {


### PR DESCRIPTION
Potential suggestion for supporting a customized ttl.

In some cases we may want to supply an algorithm to indicate
the cache expiry value.

For example, we may want to randomize the ttl to some degree
to avoid having a large number of keys expire at the same time.

One approach is to re-use the ttl parameter but allow it to be a number
or a custom function.

I didn't do any extensive testing for this.